### PR TITLE
Assign to window.global, not just global

### DIFF
--- a/examples/react/web-test-runner.config.js
+++ b/examples/react/web-test-runner.config.js
@@ -17,12 +17,11 @@ module.exports = {
   testRunnerHtml: testFramework => `
     <html>
       <head>
-        <script>
-          // Note: globals expected by @testing-library/react
-          global = window;
-          process = { env: {} };
-        </script>
         <script type="module">
+          // Note: globals expected by @testing-library/react
+          window.global = window;
+          window.process = { env: {} };
+
           // Note: adapted from https://github.com/vitejs/vite/issues/1984#issuecomment-778289660
           // Note: without this you'll run into https://github.com/vitejs/vite-plugin-react/pull/11#discussion_r430879201
           window.__vite_plugin_react_preamble_installed__ = true;

--- a/examples/svelte/web-test-runner.config.js
+++ b/examples/svelte/web-test-runner.config.js
@@ -17,10 +17,10 @@ module.exports = {
   testRunnerHtml: testFramework => `
     <html>
       <head>
-        <script>
+        <script type="module">
           // Note: globals expected by @testing-library/svelte
-          global = window;
-          process = { env: {} };
+          window.global = window;
+          window.process = { env: {} };
         </script>
         <script type="module" src="${testFramework}"></script>
       </head>

--- a/examples/vue/web-test-runner.config.js
+++ b/examples/vue/web-test-runner.config.js
@@ -17,10 +17,10 @@ module.exports = {
   testRunnerHtml: testFramework => `
     <html>
       <head>
-        <script>
+        <script type="module">
           // Note: globals expected by @testing-library/vue
-          global = window;
-          process = { env: {} };
+          window.global = window;
+          window.process = { env: {} };
         </script>
         <script type="module" src="${testFramework}"></script>
       </head>


### PR DESCRIPTION
Otherwise errors are thrown like `ReferenceError: Can't find variable: global`