### PR TITLE
Add a testing mode when running vite server

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = function () {
 
     async serverStart({ app }) {
       server = await vite.createServer({
+        mode: "TESTING",
         clearScreen: false,
       });
       await server.listen();


### PR DESCRIPTION
Adding this mode will start server in the specified (TESTING) mode, eventually users using this plugin will be able to define vite config based on this mode..

This will allow people to configure vite based on  TESTING mode.
```
export default defineConfig(async ({ mode }) => {
  console.log('****************' + mode + '*********')
  const testDeps =
    mode === 'TESTING'
      ? [
          '@testing-library/react',
          '@testing-library/user-event',
          'chai',
          'ts-mockito',
          '@testing-library/react-hooks/dom'
        ]
      : []
  return {
    server: {
      port: 9000
    },
    base: `./`,
    optimizeDeps: {
      include: testDeps
    },
    build: {
      outDir: AppConfig.applicationName,
      sourcemap: 'inline',
      rollupOptions: {
        input: ['./index.html']
      }
    },
    plugins: [reactRefresh()]
  }
})
```